### PR TITLE
Create NAT.md

### DIFF
--- a/NAT.md
+++ b/NAT.md
@@ -1,0 +1,104 @@
+# NAT
+
+## Do people sharing address beacsuse NAT
+
+```markdown
+Yes, people can share the same public IP address because of **Network Address Translation (NAT)**. This commonly happens in the following scenarios:
+
+1. **Home and Office Networks (NAT in Routers)**  
+   - Most home and office networks use a single public IP address assigned by the Internet Service Provider (ISP).
+   - Multiple devices (computers, phones, smart devices) in the network are assigned private IP addresses (e.g., `192.168.x.x` or `10.x.x.x`).
+   - The router performs NAT to translate private IP addresses into the single public IP when accessing the internet.
+   - This allows many devices to share one public IP.
+
+2. **Carrier-Grade NAT (CG-NAT)**  
+   - Some ISPs use **CG-NAT** to conserve IPv4 addresses by assigning the same public IP to multiple subscribers.
+   - This is common in mobile networks (4G, 5G) and some broadband providers.
+   - As a result, multiple unrelated users may appear to have the same public IP.
+
+3. **Cloud and Hosting Environments**  
+   - Some cloud providers use NAT to allow multiple virtual machines (VMs) to share a single public IP.
+   - Proxy servers and VPN services can also mask multiple users under the same IP.
+
+### Implications of NAT on Shared IPs:
+- **Geolocation Issues**: Websites might think multiple users are from the same physical location.
+- **Rate Limiting**: Some websites limit actions based on IP, so one user’s actions might affect others.
+- **Security and Privacy**: Shared IPs can make it harder to track specific users, but they also increase the risk of being mistakenly blocked if someone else misbehaves.
+- **Port Forwarding Needed**: NAT can make hosting services difficult unless port forwarding or UPnP is used.
+
+Would you like a more technical breakdown of how NAT functions at the packet level?
+```
+
+## Yes and also it is possible two person has same the internet protocol address even though they are not in the same NAT?
+
+```markdown
+Yes, it's possible for two individuals to share the same public IP address even if they are not on the same local network. This typically occurs due to the following reasons:
+
+1. **Carrier-Grade NAT (CGNAT):**
+   - **Explanation:** Internet Service Providers (ISPs) often use CGNAT to conserve IPv4 addresses by assigning the same public IP address to multiple customers.
+   - **Implication:** Multiple users, each with separate private networks, appear to have the same public IP address when accessing external services.
+
+2. **Proxy Servers and VPNs:**
+   - **Explanation:** When individuals connect to the internet through a shared proxy server or Virtual Private Network (VPN), their traffic is routed through a common public IP address.
+   - **Implication:** All users of the proxy or VPN service share the same public IP address, regardless of their physical locations or private networks.
+
+3. **Dynamic IP Address Allocation:**
+   - **Explanation:** ISPs often assign dynamic public IP addresses that can change over time.
+   - **Implication:** At different times, different customers may be assigned the same public IP address, though not simultaneously.
+
+**Technical Breakdown of NAT Functionality:**
+
+Network Address Translation (NAT) modifies network address information in IP packet headers while they are in transit, enabling multiple devices on a local network to access external networks using a single public IP address. Here's how it works:
+
+1. **Outgoing Traffic:**
+   - **Source IP Modification:** When a device within a private network sends data to an external network, NAT replaces the device's private IP address with the public IP address of the router.
+   - **Port Assignment:** NAT assigns a unique port number to each outgoing connection, creating a mapping of internal IP addresses and ports to the external public IP address and assigned ports.
+
+2. **Incoming Traffic:**
+   - **Destination IP and Port Matching:** When a response returns from the external network, NAT examines the destination port number and refers to its mapping table to determine the corresponding internal IP address and port.
+   - **Address Reassignment:** NAT then rewrites the destination IP address and port of the incoming packet to direct it to the appropriate internal device.
+
+This process allows multiple devices on a private network to share a single public IP address for accessing external networks, while maintaining distinct sessions through port differentiation.
+
+For a more in-depth understanding, you can refer to the Wikipedia article on [Network Address Translation](https://en.wikipedia.org/wiki/Network_address_translation).
+```
+
+## ipv4 vs ipv6
+
+```markdown
+IPv4 (Internet Protocol version 4) and IPv6 (Internet Protocol version 6) are two versions of the protocol that provide unique addresses to devices on a network, enabling them to communicate over the internet.
+
+**Key Differences Between IPv4 and IPv6:**
+
+1. **Address Space:**
+   - **IPv4:** Utilizes 32-bit addresses, allowing for approximately 4.3 billion unique addresses.
+   - **IPv6:** Employs 128-bit addresses, vastly expanding the address space to support a virtually unlimited number of devices. citeturn0search8
+
+2. **Address Notation:**
+   - **IPv4:** Addresses are written in dotted decimal format, e.g., `192.168.1.1`.
+   - **IPv6:** Addresses are expressed in hexadecimal and separated by colons, e.g., `2001:0db8:85a3:0000:0000:8a2e:0370:7334`.
+
+3. **Header Complexity:**
+   - **IPv4:** The header is more complex, containing several optional fields.
+   - **IPv6:** The header is simplified, improving processing efficiency by removing or making optional certain fields present in IPv4. citeturn0search8
+
+4. **Security:**
+   - **IPv4:** Security features are optional and not inherently built into the protocol.
+   - **IPv6:** Originally mandated IPsec support for encryption and authentication, but this was later downgraded to a recommendation. citeturn0search8
+
+5. **Address Configuration:**
+   - **IPv4:** Relies on the Dynamic Host Configuration Protocol (DHCP) for address assignment.
+   - **IPv6:** Supports Stateless Address Autoconfiguration (SLAAC), allowing devices to configure themselves automatically without a DHCP server. citeturn0search8
+
+6. **Network Address Translation (NAT):**
+   - **IPv4:** Commonly uses NAT to conserve address space, allowing multiple devices on a local network to share a single public IP address.
+   - **IPv6:** Designed to eliminate the need for NAT due to its vast address space, enabling end-to-end connectivity. citeturn0search8
+
+**Implications of Transitioning from IPv4 to IPv6:**
+
+- **Compatibility:** IPv4 and IPv6 are not directly interoperable, necessitating transition mechanisms such as dual-stack configurations or tunneling.
+- **Performance:** While IPv6 offers improved routing efficiency and simplified packet processing, actual performance gains depend on network infrastructure and proper implementation.
+- **Adoption:** The transition to IPv6 has been gradual. As of 2023, a significant portion of internet traffic still relies on IPv4, but IPv6 adoption continues to grow. citeturn0search8
+
+In summary, IPv6 addresses the limitations of IPv4, particularly the exhaustion of address space, and introduces enhancements in security, configuration, and routing. However, the full benefits of IPv6 will be realized as adoption becomes more widespread and network infrastructures are updated to support the newer protocol. 
+```


### PR DESCRIPTION
```markdown
# NAT

## Do people sharing address beacsuse NAT

```markdown
Yes, people can share the same public IP address because of **Network Address Translation (NAT)**. This commonly happens in the following scenarios:

1. **Home and Office Networks (NAT in Routers)**  
   - Most home and office networks use a single public IP address assigned by the Internet Service Provider (ISP).
   - Multiple devices (computers, phones, smart devices) in the network are assigned private IP addresses (e.g., `192.168.x.x` or `10.x.x.x`).
   - The router performs NAT to translate private IP addresses into the single public IP when accessing the internet.
   - This allows many devices to share one public IP.

2. **Carrier-Grade NAT (CG-NAT)**  
   - Some ISPs use **CG-NAT** to conserve IPv4 addresses by assigning the same public IP to multiple subscribers.
   - This is common in mobile networks (4G, 5G) and some broadband providers.
   - As a result, multiple unrelated users may appear to have the same public IP.

3. **Cloud and Hosting Environments**  
   - Some cloud providers use NAT to allow multiple virtual machines (VMs) to share a single public IP.
   - Proxy servers and VPN services can also mask multiple users under the same IP.

### Implications of NAT on Shared IPs:
- **Geolocation Issues**: Websites might think multiple users are from the same physical location.
- **Rate Limiting**: Some websites limit actions based on IP, so one user’s actions might affect others.
- **Security and Privacy**: Shared IPs can make it harder to track specific users, but they also increase the risk of being mistakenly blocked if someone else misbehaves.
- **Port Forwarding Needed**: NAT can make hosting services difficult unless port forwarding or UPnP is used.

Would you like a more technical breakdown of how NAT functions at the packet level?
```

## Yes and also it is possible two person has same the internet protocol address even though they are not in the same NAT?

```markdown
Yes, it's possible for two individuals to share the same public IP address even if they are not on the same local network. This typically occurs due to the following reasons:

1. **Carrier-Grade NAT (CGNAT):**
   - **Explanation:** Internet Service Providers (ISPs) often use CGNAT to conserve IPv4 addresses by assigning the same public IP address to multiple customers.
   - **Implication:** Multiple users, each with separate private networks, appear to have the same public IP address when accessing external services.

2. **Proxy Servers and VPNs:**
   - **Explanation:** When individuals connect to the internet through a shared proxy server or Virtual Private Network (VPN), their traffic is routed through a common public IP address.
   - **Implication:** All users of the proxy or VPN service share the same public IP address, regardless of their physical locations or private networks.

3. **Dynamic IP Address Allocation:**
   - **Explanation:** ISPs often assign dynamic public IP addresses that can change over time.
   - **Implication:** At different times, different customers may be assigned the same public IP address, though not simultaneously.

**Technical Breakdown of NAT Functionality:**

Network Address Translation (NAT) modifies network address information in IP packet headers while they are in transit, enabling multiple devices on a local network to access external networks using a single public IP address. Here's how it works:

1. **Outgoing Traffic:**
   - **Source IP Modification:** When a device within a private network sends data to an external network, NAT replaces the device's private IP address with the public IP address of the router.
   - **Port Assignment:** NAT assigns a unique port number to each outgoing connection, creating a mapping of internal IP addresses and ports to the external public IP address and assigned ports.

2. **Incoming Traffic:**
   - **Destination IP and Port Matching:** When a response returns from the external network, NAT examines the destination port number and refers to its mapping table to determine the corresponding internal IP address and port.
   - **Address Reassignment:** NAT then rewrites the destination IP address and port of the incoming packet to direct it to the appropriate internal device.

This process allows multiple devices on a private network to share a single public IP address for accessing external networks, while maintaining distinct sessions through port differentiation.

For a more in-depth understanding, you can refer to the Wikipedia article on [Network Address Translation](https://en.wikipedia.org/wiki/Network_address_translation).
```

## ipv4 vs ipv6

```markdown
IPv4 (Internet Protocol version 4) and IPv6 (Internet Protocol version 6) are two versions of the protocol that provide unique addresses to devices on a network, enabling them to communicate over the internet.

**Key Differences Between IPv4 and IPv6:**

1. **Address Space:**
   - **IPv4:** Utilizes 32-bit addresses, allowing for approximately 4.3 billion unique addresses.
   - **IPv6:** Employs 128-bit addresses, vastly expanding the address space to support a virtually unlimited number of devices. citeturn0search8

2. **Address Notation:**
   - **IPv4:** Addresses are written in dotted decimal format, e.g., `192.168.1.1`.
   - **IPv6:** Addresses are expressed in hexadecimal and separated by colons, e.g., `2001:0db8:85a3:0000:0000:8a2e:0370:7334`.

3. **Header Complexity:**
   - **IPv4:** The header is more complex, containing several optional fields.
   - **IPv6:** The header is simplified, improving processing efficiency by removing or making optional certain fields present in IPv4. citeturn0search8

4. **Security:**
   - **IPv4:** Security features are optional and not inherently built into the protocol.
   - **IPv6:** Originally mandated IPsec support for encryption and authentication, but this was later downgraded to a recommendation. citeturn0search8

5. **Address Configuration:**
   - **IPv4:** Relies on the Dynamic Host Configuration Protocol (DHCP) for address assignment.
   - **IPv6:** Supports Stateless Address Autoconfiguration (SLAAC), allowing devices to configure themselves automatically without a DHCP server. citeturn0search8

6. **Network Address Translation (NAT):**
   - **IPv4:** Commonly uses NAT to conserve address space, allowing multiple devices on a local network to share a single public IP address.
   - **IPv6:** Designed to eliminate the need for NAT due to its vast address space, enabling end-to-end connectivity. citeturn0search8

**Implications of Transitioning from IPv4 to IPv6:**

- **Compatibility:** IPv4 and IPv6 are not directly interoperable, necessitating transition mechanisms such as dual-stack configurations or tunneling.
- **Performance:** While IPv6 offers improved routing efficiency and simplified packet processing, actual performance gains depend on network infrastructure and proper implementation.
- **Adoption:** The transition to IPv6 has been gradual. As of 2023, a significant portion of internet traffic still relies on IPv4, but IPv6 adoption continues to grow. citeturn0search8

In summary, IPv6 addresses the limitations of IPv4, particularly the exhaustion of address space, and introduces enhancements in security, configuration, and routing. However, the full benefits of IPv6 will be realized as adoption becomes more widespread and network infrastructures are updated to support the newer protocol. 
```
```